### PR TITLE
Fix query to get the right local content

### DIFF
--- a/Entity/MetadataParameterRepository.php
+++ b/Entity/MetadataParameterRepository.php
@@ -26,6 +26,7 @@ class MetadataParameterRepository extends EntityRepository
             ->join('e.parameters', 'p')
             ->andWhere('e.route = :route')
             ->setParameter(':route', $route)
+            ->useQueryCache(null)
             ->getQuery()
             ->setHint(
                 Query::HINT_CUSTOM_OUTPUT_WALKER,


### PR DESCRIPTION
The cache should be disabled by the walker to avoid getting always the same locale content.
It's also possible to ->setHint('locale', $locale) to create a unique key and avoir this issue.